### PR TITLE
Add Colab link for websearch notebooks in README.md

### DIFF
--- a/web_search/README.md
+++ b/web_search/README.md
@@ -1,3 +1,5 @@
+[Open in colab](https://colab.research.google.com/drive/1FPHyR5rCfzJWOdvQs1eAEyvLr6x4DT6H?usp=sharing)
+
 # RAG Bootcamp: Web Search
 
 This is a reference implementations for Vector Institute's **RAG (Retrieval-Augmented Generation) Bootcamp**, taking place from Nov 2024 to Jan 2025. Popular LLMs like OpenAI's GPT-4o and Meta's Llama-3 are very good at natural language and sounding like humans, but their knowledge is limited by the data they were trained on. 


### PR DESCRIPTION
This PR adds a Google colab notebook link containing executable code for the 2 notebooks in `web_search`  folder.

The link is accessible to the public with `Viewer` privileges.